### PR TITLE
Check if defaultParams is undefined before concatenating

### DIFF
--- a/Koha/Plugin/EDS/js/EDSScript.js
+++ b/Koha/Plugin/EDS/js/EDSScript.js
@@ -275,6 +275,7 @@ function SearchEDS(){
 	  if(searchTerm==undefined) searchTerm = $('.transl1').val().replace(/\&/g,"%2526");} // for bootstrap
 	  
   if(knownItem=='eds'){knownItem='';}
+  if(defaultParams === undefined){defaultParams = '';}
   window.location='/plugin/Koha/Plugin/EDS/opac/eds-search.pl?q=Search?query-1=AND,'+knownItem+':{'+searchTerm+'}'+defaultParams+'&default=1';
 }
 


### PR DESCRIPTION
This patch sets "defaultParams" to blank if it's undefined.
Otherwise, if you're missing "defaultParams" in the
"edsConfig" object stored in local storage, you'll get
the string "undefined" in your search string, which
causes it to return no search results.

For example:
/plugin/Koha/Plugin/EDS/opac/eds-search.pl?q=Search?
query-1=AND,:{test}undefined&default=1

_TEST PLAN_

Assuming that you already have "defaultParams" in your local storage...

0) Do a "Discovery" search and note that you get results
1) At the "eds-search.pl" page, press F12
2) Click on the "Resources" tab
3) Click the arrow next to "Local Storage" and
click on the web address listed thre.
4) Go to the "jStorage" key
5) Right click on the value to the right of it and click
"Edit Value"

6) At this point, it would be easiest to Ctrl+A Ctrl+C,
and then edit the text in a text editor.
7) Search for "defaultParams" and remove that property
from the object.
8) Copy from the text editor back into the local storage
key-value table.
9) Refresh the page
10) Click "Go" again on your search
11) Note that your URL appears as above and your
search box will have "undefined" concatenated to the
end of your actual search string.