### PR TITLE
Fix for: Bareword "GetItemTypes" not allowed

### DIFF
--- a/Koha/Plugin/EDS/opac/eds-search.pl
+++ b/Koha/Plugin/EDS/opac/eds-search.pl
@@ -391,7 +391,7 @@ sub GetCatalogueAvailability
 	my @sort_by='relevance_asc';
 	my @servers='biblioserver';
 	my $branches = ''; # GetBranches();#  { map { $->branchcode => $->unblessed } Koha::Libraries->search };
-	my $itemtypes = GetItemTypes;
+	my $itemtypes = GetItemTypes();
 	eval {($error, $results_hashref, $facets) = getRecords($query,$query,\@sort_by,\@servers,'100',0,$expanded_facet,$branches,$itemtypes,'ccl',$scan,1);};
 	my $hits = $results_hashref->{$servers[0]}->{"hits"};
 	


### PR DESCRIPTION
When doing a search, I was getting this error:

> Software error:
> Bareword "GetItemTypes" not allowed while "strict subs" in use at /var/lib/koha/<site>/plugins/Koha/Plugin/EDS/opac/eds-search.pl line 394.
> Execution of /var/lib/koha/<site>/plugins/Koha/Plugin/EDS/opac/eds-search.pl aborted due to compilation errors.
> For help, please send mail to the webmaster ([no address given]), giving this error message and the time and date of the error.

This patch should fix the problem.