### PR TITLE
Retrieve up-to-date CGISESSID when just logged in

### DIFF
--- a/Koha/Plugin/EDS/opac/1711/opac-sendbasket.pl
+++ b/Koha/Plugin/EDS/opac/1711/opac-sendbasket.pl
@@ -196,13 +196,14 @@ END_OF_BODY
     output_html_with_http_headers $query, $cookie, $template->output;
 }
 else {
+    my $new_session_id = $cookie->value;
     $template->param(
         bib_list       => $bib_list,
         url            => "/cgi-bin/koha/opac-sendbasket.pl",
         suggestion     => C4::Context->preference("suggestion"),
         virtualshelves => C4::Context->preference("virtualshelves"),
         csrf_token => Koha::Token->new->generate_csrf(
-            { session_id => scalar $query->cookie('CGISESSID'), } ),
+            { session_id => $new_session_id, } ),
     );
     output_html_with_http_headers $query, $cookie, $template->output;
 }


### PR DESCRIPTION
Based off of fix for Koha opac-sendbasket on bug 18975

    If a user is asked to login before sending a card, the wrong (old)
    CGISESSID cookie is used.
    We need to retrieve the one that has just been created.