### PR TITLE
gss.ebscohost.com/cwu/apps/mgt/gi.png should be served over HTTP

### DIFF
--- a/Apps/maoritranslate/gtrans_maori.js
+++ b/Apps/maoritranslate/gtrans_maori.js
@@ -32,7 +32,7 @@
             top: 0px !important;\
         }\
         #g_logo{\
-            background: url(http://gss.ebscohost.com/cwu/apps/mgt/gi.png);\
+            background: url(https://gss.ebscohost.com/cwu/apps/mgt/gi.png);\
             height: 16px;\
             width: 16px;\
             background-size: cover;\


### PR DESCRIPTION
At the moment gss.ebscohost.com/cwu/apps/mgt/gi.png is served over
HTTP which gives you the following warning in the browser console:

"Mixed Content: The page at 'https://xxxxxxx.xxx/' was loaded
over HTTPS, but requested an insecure image
'http://gss.ebscohost.com/cwu/apps/mgt/gi.png'.
This content should also be served over HTTPS."

I've noticed there is a HTTPS version available,
so there's no reason not to use it.