### PR TITLE
Using patron's first valid email address as from-address before using…

### DIFF
--- a/Koha/Plugin/EDS/opac/1711/opac-sendbasket.pl
+++ b/Koha/Plugin/EDS/opac/1711/opac-sendbasket.pl
@@ -63,7 +63,7 @@ if ( $email_add ) {
     # { session_id => $new_session_id, } ),
     my $email = Koha::Email->new();
     my $patron = Koha::Patrons->find( $borrowernumber );
-    my $user_email = C4::Context->preference('KohaAdminEmailAddress');
+    my $user_email = $patron->first_valid_email_address || C4::Context->preference('KohaAdminEmailAddress');
 
     my $email_replyto = $patron->firstname . " " . $patron->surname . " <$user_email>";
     my $comment    = $query->param('comment');


### PR DESCRIPTION
… KohaAdminEmailAddress

The from-address shouldn't use the KohaAdminEmailAddress by default if the patron has a valid email address that could fill this field.