### PR TITLE
Fix bootstrap css-class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 .perlcriticrc
 OMtesting.txt
+.idea

--- a/Koha/Plugin/EDS/bootstrap/modules/eds-detail.tt
+++ b/Koha/Plugin/EDS/bootstrap/modules/eds-detail.tt
@@ -1045,7 +1045,7 @@
                 [% END # / IF Babeltheque %]
         </div> <!-- /.span8 -->
 
-        <div class="span3">
+        <div class="col-lg-3">
             <div id="ulactioncontainer">
 
                 [% IF ( OpacBrowseResults && busc ) %]


### PR DESCRIPTION
Fixes the display of the detail pages on Bootstrap 5.x based Koha (starting 24.11)